### PR TITLE
Make auto-reload-card work with more modern HA.

### DIFF
--- a/auto-reload-card.js
+++ b/auto-reload-card.js
@@ -20,19 +20,10 @@ class AutoReloadCard extends HTMLElement {
 				if(!panel) { return; }
 				const uiRoot = panel.shadowRoot.querySelector('hui-root');
 				if(!uiRoot) { return; }
-				const header = uiRoot.shadowRoot.querySelector('app-header');
-				const isEditing = header.classList.contains('edit-mode');
-				if(isEditing) { return; }
-			
-				const toolbar = uiRoot.shadowRoot.querySelector('app-toolbar');
-				const buttonMenu = toolbar.querySelector('ha-button-menu');
-				const refresh = buttonMenu.querySelector('[aria-label=Refresh]');
-			
-				if (refresh) {
-					refresh.click();
-				} else {
-					location.reload();
-				}
+				const editMode = uiRoot.shadowRoot.querySelector('.edit-mode');
+				if(editMode) { return; }
+
+				location.reload();
 			}, delay);
 			window.AutoReloadCardIntervalHandle = `${hass.panelUrl}:${intervalHandle}`;
 		}


### PR DESCRIPTION
This should fix the following issues: https://github.com/ben8p/lovelace-auto-reload-card/issues/6 https://github.com/ben8p/lovelace-auto-reload-card/issues/8 https://github.com/ben8p/lovelace-auto-reload-card/issues/9

Modern Home Assistant got rid of the apps-header.  No longer uses an edit-mode tag, but a div tag with a class of edit-mode.  And the refresh button is gone.